### PR TITLE
Fix two LP Mk3 device setup for 128 grid - to jaggednz/midigrid fork

### DIFF
--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -2,7 +2,21 @@ local supported_devices = {
   midi_devices = {
     {  midi_base_name= 'launchpad',        device_type='launchpad'     },
     {  midi_base_name= 'launchpad mini',   device_type='launchpad'     },
+    --
+    -- LP Mini MK3 presents two MIDI interfaces over USB:
+    --   launchpad mini mk3 1 - LPMiniMK3 DAW I/O (or first interface): For use
+    --                        by DAWs and similar software to interact with the
+    --                        MK3’s Session mode.
+    --   launchpad mini mk3 2 - LPMiniMK3 MIDI I/O (or second interface): Used
+    --                        to receive MIDI from Custom modes; and to provide
+    --                        external MIDI input or Light controls in
+    --                        Lighting Custom Modes and Programmer mode.
+    --
+    -- LP Mini MK3 needs to be put in Programmer mode manually for midigrid use.
     {  midi_base_name= 'launchpad mini mk3 2', device_type='launchpad_minimk3' },
+    -- A second LP Mini MK3 displays these device names:
+    --   launchpad mini mk3 1 2
+    --   launchpad mini mk3 2 2
     {  midi_base_name= 'launchpad mini mk3 2 2', device_type='launchpad_minimk3_128' },
     {  midi_base_name= 'apc mini',         device_type='apc_mini'      },
     {  midi_base_name= 'block 1',          device_type='livid_block'   },
@@ -22,6 +36,8 @@ function supported_devices.find_midi_device_type(midi_device)
   -- TODO get response to sysex indentify call
 
   if string.lower(midi_device.name):find 'launchpad mini %d' then
+    -- Old launchpad mini's have user set hardware ID 1 - 16:
+    -- e.g. ID 4 appears as midi_device.name "Launchpad Mini 4"
     return 'launchpad'
   else
     for _,device_def in pairs(supported_devices.midi_devices) do

--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -21,18 +21,19 @@ function supported_devices.find_midi_device_type(midi_device)
   local sysex_ident_resp = nil
   -- TODO get response to sysex indentify call
 
-  --'launchpad mini %d'
-  for _,device_def in pairs(supported_devices.midi_devices) do
-    if sysex_ident_resp and device_def.sysex_ident then
-      --TODO use General Sysex ident call to try and ID device
+  if string.lower(midi_device.name):find 'launchpad mini %d' then
+    return 'launchpad'
+  else
+    for _,device_def in pairs(supported_devices.midi_devices) do
+      if sysex_ident_resp and device_def.sysex_ident then
+        --TODO use General Sysex ident call to try and ID device
+      end
+      -- Fall back to midi name matching
+      -- TODO strip / ignore device name suffix for multiple devices
+      if (device_def.midi_base_name == string.lower(midi_device.name)) then return device_def.device_type end
     end
-    -- Fall back to midi name matching
-    if string.lower(midi_device.name) == device_def.midi_base_name then return device_def.device_type end
-    -- Deal with any appended suffixes
-    -- Warning! could cause issues if a new version of a device named "[device_name] 2"
-    if string.lower(midi_device.name):find(device_def.midi_base_name .. ' %d') then return device_def.device_type end
+    return nil
   end
-  return nil
 end
 
 return supported_devices


### PR DESCRIPTION
Fix two LP Mk3 device setup for 128 grid.

Without this change log is:
```
  finding device: 2 with name Launchpad Mini MK3 1
  finding device: 3 with name Launchpad Mini MK3 2
  Dev3 FD launchpad_minimk3
  finding device: 4 with name Launchpad Mini MK3 1 2
  finding device: 5 with name Launchpad Mini MK3 2 2
  Dev5 FD launchpad_minimk3
  mounted_devices
  5	launchpad_minimk3
  3	launchpad_minimk3
```

With this change log is:
```
  finding device: 2 with name Launchpad Mini MK3 1
  finding device: 3 with name Launchpad Mini MK3 2
  Dev3 FD launchpad_minimk3
  finding device: 4 with name Launchpad Mini MK3 1 2
  finding device: 5 with name Launchpad Mini MK3 2 2
  Dev5 FD launchpad_minimk3_128
  mounted_devices
  5	launchpad_minimk3_128
  3	launchpad_minimk3
```

Also tested this change with LP Mk2 and APC mini. It did not effect the loading behaviour of these devices.

Added comments to code explaining LP MIDI device names.
