### PR TITLE
Push 2 support

### DIFF
--- a/lib/devices/push2.lua
+++ b/lib/devices/push2.lua
@@ -1,0 +1,46 @@
+-- mods on the generic device for Push 2
+local push = include('midigrid/lib/devices/generic_device')
+
+print('loading push')
+
+-- mapping for Push's main pads
+push.grid_notes = {
+      {92, 93, 94, 95, 96, 97, 97, 99},
+      {84, 85, 86, 97, 88, 89, 90, 91},
+      {76, 77, 78, 79, 80, 81, 82, 83},
+      {68, 69, 70, 71, 72, 73, 74, 75},
+      {60, 61, 62, 63, 64, 65, 66, 67},
+      {52, 53, 54, 55, 56, 57, 58, 59},
+      {44, 45, 46, 47, 48, 49, 50, 51},
+      {36, 37, 38, 39, 40, 41, 42, 43}
+}
+
+-- probably want to change these as I've not thought to much about them at this point :-)
+push.brightness_map = {0,11,11,9,9,9,13,13,51,51,51,49,49,59,59,57}
+
+
+push.auxcol = {102,103,104,105,106,107,108,109}
+push.auxrow = {20,21,22,23,24,25,26,27}
+
+-- no pads to control quad
+push.quad_leds = {notes = nil}
+
+-- todo: add CCs for controlling quads?
+-- push.quad_leds = {CC = {}}
+
+-- todo decide what to do here as we have a lot of buttons
+push.cc_event_handlers = {}
+push.cc_event_handlers[20] = function(self,val)  self:change_quad(1) end
+push.cc_event_handlers[21] = function(self,val)  self:change_quad(2) end
+push.cc_event_handlers[22] = function(self,val)  self:change_quad(3) end
+push.cc_event_handlers[23] = function(self,val)  self:change_quad(4) end
+
+function push:cc_handler(vgrid,midi_msg)
+      if self.cc_event_handlers[midi_msg.cc] then
+            self.cc_event_handlers[midi_msg.cc](self,midi_msg.val)
+      else
+            print('Unhandled CC '.. midi_msg.cc)
+      end
+end
+
+return push

--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -5,7 +5,10 @@ local supported_devices = {
     
     {  midi_base_name= 'apc mini',         device_type='apc_mini'      },
     {  midi_base_name= 'block 1',          device_type='livid_block'   },
-    
+
+    -- Ableton Push 2
+    {  midi_base_name= 'ableton push 2 1',          device_type='push2'   },
+
     -- Novation Launchpads 
     
     {  midi_base_name= 'launchpad',        device_type='launchpad'       },


### PR DESCRIPTION
Added basic support for Ableton's Push 2.

The required changes are very small as midigrid already does most of the heavy lifting. I've tested on Cheat Codes 2, running in 64 grid mode and it's great. The colour mapping could be better, but it will do for now.

At the moment it supports the pads, and the left most 4 buttons under the LCD can be used to switch quads.

It would be really nice to expose a callback to the user of the grid so they can use the other buttons, as there are a lot of them, including all the play, record, and so no. Of course, this goes beyond a grid emulation, but seems like it could be useful.

Kind regards,

Ben