### PR TITLE
Automatically switch Launchpad mini mk3 / Launchpad X to Programmer Mode

### DIFF
--- a/lib/devices/generic_device.lua
+++ b/lib/devices/generic_device.lua
@@ -39,6 +39,8 @@ local device={
   device_name = 'generic'
 }
 
+function device:init() end -- optional init function
+
 --function expects grid brightness from 0-15 and converts in so your midi controller can understand,
 -- these values need to be adjusted for your controller!
 function device:brightness_handler(val)

--- a/lib/devices/launchpad_minimk3.lua
+++ b/lib/devices/launchpad_minimk3.lua
@@ -1,3 +1,15 @@
 local launchpad = include('midigrid/lib/devices/launchpad_rgb')
 
+-- https://llllllll.co/t/how-do-i-send-midi-sysex-messages-on-norns/34359/14
+function launchpad:init()
+  print('Setting Launchpad Programmer mode')
+  m = midi.devices[launchpad.midi_id]
+  d = {0x0,0x20,0x29,0x02,0x0D,0x00,0x7F}
+  m:send{0xf0}
+  for i,v in ipairs(d) do
+    m:send{d[i]}
+  end
+  m:send{0xf7}
+end
+
 return launchpad

--- a/lib/devices/launchpad_minimk3_128.lua
+++ b/lib/devices/launchpad_minimk3_128.lua
@@ -1,4 +1,4 @@
-local launchpad = include('midigrid/lib/devices/launchpad_rgb')
+local launchpad = include('midigrid/lib/devices/launchpad_minimk3')
 
 --Rotate the second LP, by transposing the grid notes.
 

--- a/lib/devices/launchpad_x.lua
+++ b/lib/devices/launchpad_x.lua
@@ -2,4 +2,16 @@ local launchpad = include('midigrid/lib/devices/launchpad_rgb')
 
 launchpad.device_name = 'launchpad_x'
 
+-- https://llllllll.co/t/how-do-i-send-midi-sysex-messages-on-norns/34359/14
+function launchpad:init()
+  print('Setting Launchpad Programmer mode')
+  m = midi.devices[launchpad.midi_id]
+  d = {0x0,0x20,0x29,0x02,0x0D,0x00,0x7F}
+  m:send{0xf0}
+  for i,v in ipairs(d) do
+    m:send{d[i]}
+  end
+  m:send{0xf7}
+end
+
 return launchpad

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -95,6 +95,7 @@ function midigrid._load_midi_devices(midi_devs)
     print("Loading midi device type:" .. midi_device_type .. " on midi port " .. midi_id)
     local device = include('midigrid/lib/devices/'..midi_device_type)
     device.midi_id = midi_id
+    device.init() -- initialize device if necessary
     connected_devices[midi_id] = device
   end
 


### PR DESCRIPTION
Currently, we have to set "Programmer Mode" manually after each boot for things to work. This patch sends the corresponding SysEx message to do this automatically.

**Note:** The only downside to this is that we can not manually switch back to any other mode. According to the [Programmer's Reference](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjlkOH2yKrvAhWXNewKHc1KDbIQFjAAegQIAxAD&url=https%3A%2F%2Fwww.djshop.gr%2FAttachment%2FDownloadFile%3FdownloadId%3D10737&usg=AOvVaw02Njpg1AY5jOV7Z6gjcw5W)

> When selecting Programmer mode using this SysEx message, the Setup entry (holding down Session for half a second) is disabled. To return the Launchpad Mini [MK3]to normal operation, use this SysEx message to select any other layout than Programmer mode.  

This means that you currently need to unplug/replug the launchpad to use it as a normal MIDI device. 

Maybe I should add a script that sets the launchpad back to it's normal view? 