### PR TITLE
Fix rgb 128

### DIFF
--- a/lib/devices/launchpad_minimk3.lua
+++ b/lib/devices/launchpad_minimk3.lua
@@ -3,4 +3,27 @@ local launchpad = include('midigrid/lib/devices/launchpad_rgb')
 --Put the device into programmers mode
 launchpad.init_device_msg = { 0xf0,0x0,0x20,0x29,0x02,0x0D,0x00,0x7F,0xf7 }
 
+launchpad.aux.col = {
+  {'cc', 89, 0},
+  {'cc', 79, 0},
+  {'cc', 69, 0},
+  {'cc', 59, 0},
+  {'cc', 49, 0},
+  {'cc', 39, 0},
+  {'cc', 29, 0},
+  {'cc', 19, 0}
+}
+
+launchpad.aux.row = {
+  {'cc', 91, 0},
+  {'cc', 92, 0},
+  {'cc', 93, 0},
+  {'cc', 94, 0},
+  {'cc', 95, 0},
+  {'cc', 96, 0},
+  {'cc', 97, 0},
+  {'cc', 98, 0}
+}
+
+
 return launchpad

--- a/lib/devices/launchpad_rgb.lua
+++ b/lib/devices/launchpad_rgb.lua
@@ -50,14 +50,14 @@ launchpad.aux.col = {
 }
 --left to right, 91 is aux key to column 1
 launchpad.aux.row = {
-  {'note', 91, 0},
-  {'note', 92, 0},
-  {'note', 93, 0},
-  {'note', 94, 0},
-  {'note', 95, 0},
-  {'note', 96, 0},
-  {'note', 97, 0},
-  {'note', 98, 0}
+  {'cc', 104, 0},
+  {'cc', 105, 0},
+  {'cc', 106, 0},
+  {'cc', 107, 0},
+  {'cc', 108, 0},
+  {'cc', 109, 0},
+  {'cc', 110, 0},
+  {'cc', 111, 0}
 }
 
 return launchpad

--- a/lib/devices/launchpad_x.lua
+++ b/lib/devices/launchpad_x.lua
@@ -3,4 +3,26 @@ local launchpad = include('midigrid/lib/devices/launchpad_rgb')
 --Put the device into programmers mode
 launchpad.init_device_msg = { 0xf0,0x0,0x20,0x29,0x02,0x0D,0x00,0x7F,0xf7 }
 
+launchpad.aux.col = {
+  {'cc', 89, 0},
+  {'cc', 79, 0},
+  {'cc', 69, 0},
+  {'cc', 59, 0},
+  {'cc', 49, 0},
+  {'cc', 39, 0},
+  {'cc', 29, 0},
+  {'cc', 19, 0}
+}
+
+launchpad.aux.row = {
+  {'cc', 91, 0},
+  {'cc', 92, 0},
+  {'cc', 93, 0},
+  {'cc', 94, 0},
+  {'cc', 95, 0},
+  {'cc', 96, 0},
+  {'cc', 97, 0},
+  {'cc', 98, 0}
+}
+
 return launchpad

--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -26,11 +26,12 @@ local supported_devices = {
     --   launchpad mini mk3 1 2
     --   launchpad mini mk3 2 2
     -- LP Mini MK3 needs to be put in Programmer mode manually for midigrid use.
-    { midi_base_name= 'launchpad mk2',         device_type='launchpad_rgb'   },
-    { midi_base_name= 'launchpad mini mk3 2',  device_type='launchpad_minimk3' },
-    { midi_base_name= 'launchpad pro mk3',     device_type='launchpad_rgb' },
-    { midi_base_name= 'launchpad x 2',         device_type='launchpad_x' },
-    
+    { midi_base_name= 'launchpad mk2',          device_type='launchpad_rgb'   },
+    { midi_base_name= 'launchpad mini mk3 2',   device_type='launchpad_minimk3' },
+    { midi_base_name= 'launchpad mini mk3 2 2', device_type='launchpad_minimk3_128' },
+    { midi_base_name= 'launchpad pro mk3',      device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad x 2',          device_type='launchpad_x' },
+
     -- Ableton Push 2
     { midi_base_name= 'ableton push 2 1',          device_type='push2'   },
 


### PR DESCRIPTION
These are fixes currently required to get the launchpad mini mk3 in "128 mode" running. 

Note that I also fixed the auxcols for the mk2 RGB launchpad. I can't test this but I followed the [programmers reference](https://d2xhy469pqj8rc.cloudfront.net/sites/default/files/novation/downloads/10529/launchpad-mk2-programmers-reference-guide-v1-02.pdf)

Maybe you should group launchpad mk2 and Launchpad X/Mini mk3 separately since it seems like their specification is different.

Thanks for the update! Looks like everything else is working :)