### PR TITLE
Update supported_devices.lua

### DIFF
--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -30,6 +30,9 @@ local supported_devices = {
     { midi_base_name= 'launchpad mini mk3 2',   device_type='launchpad_minimk3' },
     { midi_base_name= 'launchpad mini mk3 2 2', device_type='launchpad_minimk3' },
     { midi_base_name= 'launchpad pro mk3',      device_type='launchpad_rgb' },
+    { midi_base_name= 'Launchpad Pro mk3 1',    device_type='launchpad_rgb' },
+    { midi_base_name= 'Launchpad Pro mk3 2',    device_type='launchpad_rgb' },
+    { midi_base_name= 'Launchpad Pro mk3 3',    device_type='launchpad_rgb' },
     { midi_base_name= 'launchpad x 2',          device_type='launchpad_x' },
     { midi_base_name= 'launchpad x 2 2',        device_type='launchpad_x' },
     
@@ -37,7 +40,9 @@ local supported_devices = {
     { midi_base_name= 'ableton push 2 1',          device_type='push2'   },
     
     -- Linnstrument
+    -- The Linnstrument has to be put into custom user firmware mode. Press Global Settings and then Hold down Update OS to enter this.
     { midi_base_name= 'linnstrument midi',          device_type='linnstrument'   },
+    { midi_base_name= 'LinnStrument MIDI',          device_type='linnstrument'   },
 
   }
 }


### PR DESCRIPTION
I had problems getting both my Launchpad Pro Mk 3 and my Linnstrument recognised, but adding these additional lines included helped.

Specifically, the Linnstrument is named 'Linnstrument MIDI'. and the Launchpad Pro Mk 3 requires some additional numbers after the name to allow for how Shield is detecting them. 