### PR TITLE
changed midi mapping for the aux columns of akai apc mini

### DIFF
--- a/lib/devices/apc_mini.lua
+++ b/lib/devices/apc_mini.lua
@@ -7,25 +7,25 @@ apcmini.brightness_map = {0,1,1,1,1,1,1,1,3,3,3,3,5,5,5,5}
  apcmini.aux = {}
  
  apcmini.aux.col = {
-    {'note',  70, 1},
-    {'note',  71, 2},
-    {'note',  72, 3},
-    {'note',  73, 4},
-    {'note',  74, 10},
-    {'note',  75, 12},
-    {'note',  76, 14},
-    {'note',  77, 16}
+    {'note',  82, 1},
+    {'note',  83, 2},
+    {'note',  84, 3},
+    {'note',  85, 4},
+    {'note',  86, 10},
+    {'note',  87, 12},
+    {'note',  88, 14},
+    {'note',  89, 16}
   }
   --left to right, 52 is aux key to column 1
   apcmini.aux.row = {
-    {'note',  52, 1},
-    {'note',  53, 2},
-    {'note',  54, 3},
-    {'note',  55, 4},
-    {'note',  56, 10},
-    {'note',  57, 12},
-    {'note',  58, 14},
-    {'note',  59, 16}
+    {'note',  64, 1},
+    {'note',  65, 2},
+    {'note',  66, 3},
+    {'note',  67, 4},
+    {'note',  68, 10},
+    {'note',  69, 12},
+    {'note',  70, 14},
+    {'note',  71, 16}
   }
 
 return apcmini


### PR DESCRIPTION
Hi,

I tried using midigrid with Akai APC Mini and it was misbehaving on my controller. I noticed that according to this: ![apc mini midi mapping](https://preview.redd.it/h1qia0k09fh31.jpg?width=490&format=pjpg&auto=webp&s=90858daa60e3e1656551333dd1c20f69d8bcc4f6) the aux row and columns have wrong values. I changed them according to the picture and now as far as I can tell the APC mini behaves correctly - changing the aux page offsets the value of `x/y` being passed to key handler and now the leds in grid are lit/unlit in correct places.

I would really appreciate if someone else with Akai APC Mini could test it but I think the midi note values should be consistent through out all the APC Minis.