### PR TITLE
Update supported devices

### DIFF
--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -32,6 +32,10 @@ local supported_devices = {
     { midi_base_name= 'launchpad pro mk3',      device_type='launchpad_rgb' },
     { midi_base_name= 'launchpad x 2',          device_type='launchpad_x' },
     { midi_base_name= 'launchpad x 2 2',        device_type='launchpad_x' },
+    { midi_base_name= 'launchpad Pro 1',        device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad Pro 2',        device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad Pro 3',        device_type='launchpad_rgb' },
+    
     
     -- Ableton Push 2
     { midi_base_name= 'ableton push 2 1',          device_type='push2'   },


### PR DESCRIPTION
This was how I got my Launchpad Pro (Mk2) working correctly. Print output: 
```
Launchpad Pro 1	 -- Not supported
###Midi device	Launchpad Pro 2
launchpad_rgb	 -- Supported
###Midi device	Launchpad Pro 3
Launchpad Pro 3	 -- Not supported
```