### PR TITLE
Update support for Launchpad Pro Mk 3

### DIFF
--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -29,7 +29,9 @@ local supported_devices = {
     { midi_base_name= 'launchpad mk2',          device_type='launchpad_rgb'   },
     { midi_base_name= 'launchpad mini mk3 2',   device_type='launchpad_minimk3' },
     { midi_base_name= 'launchpad mini mk3 2 2', device_type='launchpad_minimk3' },
-    { midi_base_name= 'launchpad pro mk3',      device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad pro mk3 1',    device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad pro mk3 2',    device_type='launchpad_rgb' },
+    { midi_base_name= 'launchpad pro mk3 3',    device_type='launchpad_rgb' },
     { midi_base_name= 'launchpad x 2',          device_type='launchpad_x' },
     { midi_base_name= 'launchpad x 2 2',        device_type='launchpad_x' },
     


### PR DESCRIPTION
Launchpad Pro Mk 3 presents itself as `Launchpad Pro Mk 3 {1,3}`. This patch updates the supported_devices script to use the correct names and recognize the device without modification.