### PR TITLE
Short circuit _update_led on bad coords

### DIFF
--- a/lib/devices/generic_device.lua
+++ b/lib/devices/generic_device.lua
@@ -85,6 +85,11 @@ function device:_reset()
 end
 
 function device._update_led(self,x,y,z)
+  if y < 1 or #self.grid_notes < y or x < 1 or #self.grid_notes[y] < x then
+    print("_update_led: x="..x.."; y="..y.."; z="..z)
+    return
+  end
+
   local vel = self.brightness_map[z+1]
   local note = self.grid_notes[y][x]
   local midi_msg = {0x90,note,vel}


### PR DESCRIPTION
Add some bounds checking inside `device._update_led` in `generic_device.lua` to defend against scripts that try to set LEDs at invalid coordinates.

Combined with #23 this allows Fall to run without crashing.