### PR TITLE
Return nil if coordinates are outside of grid size for 64 square layout

### DIFF
--- a/lib/vgrid.lua
+++ b/lib/vgrid.lua
@@ -24,7 +24,10 @@ function Vgrid:init(layout)
   self.layout = layout or '128'
   print("vgrid init with layout: ".. self.layout)
   if self.layout == '64' then
-    self.locate_in_layout = function(self,x,y) return 1 end
+    self.locate_in_layout = function(self,x,y) 
+      if (x > self.width or y > self.height) then 
+        return nil end 
+      return 1 end
     self.new_quad(1,8,8,0,0)
      
   elseif self.layout == '128' or '256' then


### PR DESCRIPTION
Layout of 64 always returns grid 1, which eventually leads to a crash in _relative_set when a script attempts to set a square that's outside of the grid

Fix that by returning nil if the square is outside of the grid