### PR TITLE
Ignore grid positions which are below 1 in x or y.

### DIFF
--- a/lib/vgrid.lua
+++ b/lib/vgrid.lua
@@ -24,14 +24,15 @@ function Vgrid:init(layout)
   self.layout = layout or '128'
   print("vgrid init with layout: ".. self.layout)
   if self.layout == '64' then
-    self.locate_in_layout = function(self,x,y) 
-      if (x > self.width or y > self.height) then 
-        return nil end 
+     self.locate_in_layout = function(self,x,y)
+      if (x < 1 or y < 1) then return nil end
+      if (x > self.width or y > self.height) then return nil end
       return 1 end
     self.new_quad(1,8,8,0,0)
      
   elseif self.layout == '128' or '256' then
     self.locate_in_layout = function(self,x,y)
+      if (x < 1 or y < 1) then return nil end
       if (x > self.width or y > self.height) then return nil end
       if (y <= self.quads[1].height) then
         if (x <= self.quads[1].width) then return 1 else return 2 end


### PR DESCRIPTION
Ignore not only grid positions which are beyond the width or height, but also ones which are less than 1. I am not familiar with all this quad-stuff, so I hope this would not break anything, and kindly ask someone more familiar with that quad-stuff in `self.locate_in_layout(self, x, y)` in `Vgrid:init` to review this change.

This, plus the intensity at #36 makes awake work (although there might be an off-by-one in there when awake marks a silent note)