### PR TITLE
add support for launchpad pro mk1

### DIFF
--- a/lib/devices/launchpad_pro_mk1.lua
+++ b/lib/devices/launchpad_pro_mk1.lua
@@ -1,0 +1,28 @@
+local launchpad = include('midigrid/lib/devices/launchpad_rgb')
+
+--Put the device into programmers mode
+launchpad.init_device_msg = { 0xf0,0x00,0x20,0x29,0x02,0x10,0x2c,0x03,0xf7 }
+
+launchpad.aux.col = {
+  {'cc', 89, 0},
+  {'cc', 79, 0},
+  {'cc', 69, 0},
+  {'cc', 59, 0},
+  {'cc', 49, 0},
+  {'cc', 39, 0},
+  {'cc', 29, 0},
+  {'cc', 19, 0}
+}
+
+launchpad.aux.row = {
+  {'cc', 91, 0},
+  {'cc', 92, 0},
+  {'cc', 93, 0},
+  {'cc', 94, 0},
+  {'cc', 95, 0},
+  {'cc', 96, 0},
+  {'cc', 97, 0},
+  {'cc', 98, 0}
+}
+
+return launchpad

--- a/lib/supported_devices.lua
+++ b/lib/supported_devices.lua
@@ -33,6 +33,8 @@ local supported_devices = {
     -- Confusingly unlike the x and mini the pro answers to programmer messages on interface *1* not 2.
     { midi_base_name= 'launchpad pro mk3 1',    device_type='launchpad_pro_mk3' },
     { midi_base_name= 'launchpad pro mk3 1 1',  device_type='launchpad_pro_mk3' },
+    { midi_base_name= 'launchpad pro 2',    device_type='launchpad_pro_mk1' },
+    { midi_base_name= 'launchpad pro 2 2',  device_type='launchpad_pro_mk1' },
     { midi_base_name= 'launchpad x 2',          device_type='launchpad_x' },
     { midi_base_name= 'launchpad x 2 2',        device_type='launchpad_x' },
     { midi_base_name= 'launchpad open 2',       device_type='launchpad_x' },


### PR DESCRIPTION
Pro mk1 is similar to mk3 in programmer.

But different init syx, use port 2.